### PR TITLE
Correcting documentation for app_lib_settings_get_encryption_key_f and app_lib_settings_get_authentication_key_f

### DIFF
--- a/api/wms_settings.h
+++ b/api/wms_settings.h
@@ -332,10 +332,7 @@ typedef app_res_e
     (*app_lib_settings_set_node_role_f)(app_lib_settings_role_t role);
 
 /**
- * @brief Check if authentication key is set
- *
- * It is not possible to actually read the key from the stack.
- * The @p key_p parameter is ignored.
+ * @brief Get authentication key
  *
  * @param   key_p
  *          If NULL, key is not return but return code will inform if keys are set or not.
@@ -370,10 +367,7 @@ typedef app_res_e
     (*app_lib_settings_set_authentication_key_f)(const uint8_t * key_p);
 
 /**
- * @brief Check if encryption key is set
- *
- * It is not possible to actually read the key from the stack.
- * The @p key_p parameter is ignored.
+ * @brief Get encryption key
  *
  * @param   key_p
  *          If NULL, key is not return but return code will inform if keys are set or not.


### PR DESCRIPTION
As of Wirepas 5.2 single MCU applications are able to retrieve the authentication and encryption keys to support local provisioning: https://developer.wirepas.com/support/solutions/articles/77000513341-wirepas-massive-firmware-v5-2-release-notes

Existing documentation and wms_settings.h matches the legacy (<5.2) behaviour.